### PR TITLE
Fix duplication of block objects with multiple style blocks

### DIFF
--- a/fixture.css
+++ b/fixture.css
@@ -3,3 +3,9 @@
     --mainColor: #123456;
 }
 /* @end color */
+
+/* @start font */
+:root {
+    --mainFont: Arial;
+}
+/* @end font */

--- a/index.js
+++ b/index.js
@@ -33,11 +33,17 @@ module.exports = function (css) {
             }
 
             if (flag.start === true && flag.end === true && tmpNodes.length !== 0) {
-                results.push({
-                    name: flag.name,
-                    nodes: tmpNodes
-                })
-                tmpNodes = []
+                var exists = results.filter(obj => {
+                  return obj.name === flag.name;
+                });
+
+                if (!exists.length > 0) {
+                    results.push({
+                        name: flag.name,
+                        nodes: tmpNodes
+                    })
+                    tmpNodes = []
+                }
             }
         })
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function (css) {
             }
 
             if (flag.start === true && flag.end === true && tmpNodes.length !== 0) {
-                var exists = results.filter(obj => {
+                var exists = results.filter(function(obj) {
                   return obj.name === flag.name;
                 });
 

--- a/test.js
+++ b/test.js
@@ -9,5 +9,8 @@ test('test', function (t) {
 
     t.equal(actual[0].name, 'color')
     t.equal(actual[0].nodes.length, 1)
+
+    t.equal(actual[1].name, 'font')
+    t.equal(actual[1].nodes.length, 1)
     t.end()
 })


### PR DESCRIPTION
I was trying to use multiple style blocks to self-generate different sections in a styleguide I'm building when I noticed something odd.  It seemed that for each comment block, it would duplicate the first comment block that number of times.

For example if you had comment blocks: `@start color`, `@start font`, and `@start breakpoints`. The output would be an array of three `@color` objects. All I did here was make sure it didn't add a new object to the results array if the `object[flag.name]` already existed.